### PR TITLE
Allow multi projects

### DIFF
--- a/gemsetcleaner
+++ b/gemsetcleaner
@@ -91,9 +91,9 @@ do
             continue
         fi
         
-        ruby_version=$(cat "$project_dir/.ruby-version" | grep -oP '\d\.\d\.\d')
+        ruby_version=$(cat "$project_dir/.ruby-version" | grep -oP '\d+\.\d+\.\S+')
         if [ -z "$ruby_version" ]; then
-            ruby_version=$(cat Gemfile | grep 'ruby ' | grep -oP '\d\.\d\.\d')
+            ruby_version=$(cat Gemfile | grep 'ruby ' | grep -oP '\d+\.\d+\.\S+')
         fi
 
         ruby_gemset=$(cat "$project_dir/.ruby-gemset")

--- a/gemsetcleaner
+++ b/gemsetcleaner
@@ -70,6 +70,7 @@ fi
 existing_gemsets=()
 unused_gemsets=()
 
+echo "Detected project gemsets:"
 for workspace in "$@"
 do
     cd $workspace
@@ -102,6 +103,7 @@ do
         existing_gemsets+=($existing_gemset)
     done
 done
+echo ""
 
 # ==============================================================================
 # ==============================================================================

--- a/gemsetcleaner
+++ b/gemsetcleaner
@@ -66,36 +66,42 @@ fi
 # ==============================================================================
 # ==============================================================================
 
-# Goes to the specified workspace directory
-cd $1
-
 # Initializes some variables
-projects=$(ls -d */)
-workspace_dir=$PWD
 existing_gemsets=()
 unused_gemsets=()
 
-# Loops through the projects found in the workspace directory, and find out
-# which ruby version and gemset each one is using, storing this in the
-# "existing_gemsets" array.
-for project in $projects
+for workspace in "$@"
 do
-    project_dir="$workspace_dir/$project"
-    
-    # Skip this project if it doesn't contain the .ruby-version and .ruby-gemset
-    # files.
-    if ! [ -f "$project_dir/.ruby-version" ] ||
-       ! [ -f "$project_dir/.ruby-gemset" ]; then
-        continue
-    fi
-    
-    ruby_version=$(cat "$project_dir/.ruby-version")
-    ruby_gemset=$(cat "$project_dir/.ruby-gemset")
-    existing_gemset="$HOME/.rvm/gems/ruby-$ruby_version@$ruby_gemset/"
-    
-    existing_gemsets+=($existing_gemset)
-done
+    cd $workspace
+    workspace_dir=$PWD
+    projects=$(ls -d */)
+    # Loops through the projects found in the workspace directory, and find out
+    # which ruby version and gemset each one is using, storing this in the
+    # "existing_gemsets" array.
+    for project in $projects
+    do
+        project_dir="$workspace_dir/$project"
+        
+        # Skip this project if it doesn't contain the .ruby-version and .ruby-gemset
+        # files or a Gemfile
+        if ! [ -f "$project_dir/Gemfile" ] ||
+           ! [ -f "$project_dir/.ruby-version" ] ||
+           ! [ -f "$project_dir/.ruby-gemset" ]; then
+            continue
+        fi
+        
+        ruby_version=$(cat "$project_dir/.ruby-version" | grep -oP '\d\.\d\.\d')
+        if [ -z "$ruby_version" ]; then
+            ruby_version=$(cat Gemfile | grep 'ruby ' | grep -oP '\d\.\d\.\d')
+        fi
 
+        ruby_gemset=$(cat "$project_dir/.ruby-gemset")
+        existing_gemset="$HOME/.rvm/gems/ruby-$ruby_version@$ruby_gemset/"
+        echo $existing_gemset
+
+        existing_gemsets+=($existing_gemset)
+    done
+done
 
 # ==============================================================================
 # ==============================================================================


### PR DESCRIPTION
Hi!

I have multiple projects in multiple workspaces. By using your script to clean up one workspace, it will clean up the other workspaces too. I've adjusted your `gemsetcleaner` to be able to check multiple projects in multiple workspaces. So I think I can update yours too. Here's the PR.

### Example
**Usage:**
```
./gemsetcleaner ~/workspace1 ~/workspace2 ~/workspace3
```
**Output:**
```
Detected project gemsets:
/home/mgsrizqi/.rvm/gems/ruby-2.5.0@project3inworkspace1/
/home/mgsrizqi/.rvm/gems/ruby-2.4.2@project2inworkspace2/
/home/mgsrizqi/.rvm/gems/ruby-2.4.1@project7inworkspace2/
/home/mgsrizqi/.rvm/gems/ruby-2.3.0@project4inworkspace3/

A total of 3 unused gemsets were found:

  01) /home/mgsrizqi/.rvm/gems/ruby-2.5.0@project3inworkspace1/
  02) /home/mgsrizqi/.rvm/gems/ruby-2.4.2@project2inworkspace2/
  03) /home/mgsrizqi/.rvm/gems/ruby-2.3.0@project4inworkspace3/

Are you sure you want to remove these 3 gemsets? (yes/no)
```